### PR TITLE
feat: remove "no theme" option when defaultTheme is defined

### DIFF
--- a/src/register.tsx
+++ b/src/register.tsx
@@ -12,13 +12,13 @@ import getCookie from './getCookie';
 import { ADDON_ID, ADDON_PARAM_KEY, CLEAR_LABEL } from './constants';
 
 type Files = {
-  [key: string]: any
+  [key: string]: any;
 };
 
 type Params = {
-  files?: Files,
-  theme?: string,
-  defaultTheme?: string
+  files?: Files;
+  theme?: string;
+  defaultTheme?: string;
 };
 
 const IconButtonWithLabel = styled(IconButton)(() => ({
@@ -44,7 +44,8 @@ const Dropdown = () => {
   const cookieTheme = getCookie('cssVariables');
   const addonParams: Params = useParameter(ADDON_PARAM_KEY, {});
   const { theme, defaultTheme, files } = addonParams;
-  const id = files && Object.hasOwnProperty.call(files, cookieTheme) && cookieTheme;
+  const id =
+    files && Object.hasOwnProperty.call(files, cookieTheme) && cookieTheme;
   const [selected, setSelected] = useState(theme || id);
 
   const emit = useChannel({});
@@ -71,8 +72,10 @@ const Dropdown = () => {
 
   function generateLinks(items: Files, onHide: () => void) {
     // eslint-disable-next-line max-len
-    const result: any[] = Object.keys(items).map((value) => toLink(value, value === selected, onHide));
-    if (selected !== CLEAR_LABEL) {
+    const result: any[] = Object.keys(items).map((value) =>
+      toLink(value, value === selected, onHide),
+    );
+    if (selected !== CLEAR_LABEL && !defaultTheme) {
       result.unshift(toLink(CLEAR_LABEL, false, onHide));
     }
     return result;
@@ -84,9 +87,7 @@ const Dropdown = () => {
         placement="top"
         trigger="click"
         tooltip={({ onHide }) => (
-          <TooltipLinkList
-            links={generateLinks(files, onHide)}
-          />
+          <TooltipLinkList links={generateLinks(files, onHide)} />
         )}
         closeOnClick
       >
@@ -96,7 +97,9 @@ const Dropdown = () => {
           active={Object.hasOwnProperty.call(files, selected)}
         >
           <Icons icon="paintbrush" />
-          <ActiveViewportLabel title="Theme">{selected || 'No theme'}</ActiveViewportLabel>
+          <ActiveViewportLabel title="Theme">
+            {selected || 'No theme'}
+          </ActiveViewportLabel>
         </IconButtonWithLabel>
       </WithTooltip>
     );


### PR DESCRIPTION
Resolves #16.

An alternative that could be considered is to remove the "No theme" option internally completely, and allow consumers to define it as `'No theme': null,` as one of the options. But I suspect in most cases when defaultTheme is suggested, a no theme option is not expected.

The rest of the whitespace changes came from prettier (I have autoformat on save enabled in my editor) - I can revert those, if necessary, but maybe there should be some enforcement of the prettier code style instead.