### PR TITLE
Mark storybook icons as external

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "@etchteam/storybook-addon-css-variables-theme",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@etchteam/storybook-addon-css-variables-theme",
-      "version": "2.1.2",
+      "version": "3.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@storybook/icons": "^1.2.9"
-      },
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
@@ -21,6 +18,7 @@
         "@storybook/client-logger": "8.0.9",
         "@storybook/components": "8.0.9",
         "@storybook/core-events": "8.0.9",
+        "@storybook/icons": "^1.2.9",
         "@storybook/manager-api": "8.0.9",
         "@storybook/preview-api": "^8.0.9",
         "@storybook/react-webpack5": "^8.0.9",
@@ -5122,6 +5120,7 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.2.9.tgz",
       "integrity": "sha512-cOmylsz25SYXaJL/gvTk/dl3pyk7yBFRfeXTsHvTA3dfhoU/LWSq0NKL9nM7WBasJyn6XPSGnLS4RtKXLw5EUg==",
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       },
@@ -12244,7 +12243,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -13025,6 +13025,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -14672,6 +14673,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14729,6 +14731,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -15331,6 +15334,7 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.1.tgz",
       "integrity": "sha512-5GKS5JGfiah1O38Vfa9srZE4s3wdHbwjlCrvIookrg2FO9aIwKLOJXuJQFlEfNcVSOXuaL2hzDeY20uVXcUtrw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etchteam/storybook-addon-css-variables-theme",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "description": "Switch CSS files to change themes",
   "type": "module",
   "main": "dist/index.js",
@@ -53,9 +53,6 @@
     "url": "https://github.com/etchteam/storybook-addon-css-variables-theme/issues"
   },
   "homepage": "https://github.com/etchteam/storybook-addon-css-variables-theme#readme",
-  "dependencies": {
-    "@storybook/icons": "^1.2.9"
-  },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
@@ -66,6 +63,7 @@
     "@storybook/client-logger": "8.0.9",
     "@storybook/components": "8.0.9",
     "@storybook/core-events": "8.0.9",
+    "@storybook/icons": "^1.2.9",
     "@storybook/manager-api": "8.0.9",
     "@storybook/preview-api": "^8.0.9",
     "@storybook/react-webpack5": "^8.0.9",

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -5,9 +5,6 @@ import { defineConfig } from 'tsup';
 // The current browsers supported by Storybook v7
 const BROWSER_TARGET = ['chrome100', 'safari15', 'firefox91'];
 const NODE_TARGET = ['node18'];
-const globalManagerPackagesExcludingIcons = globalManagerPackages.filter(
-  (packageName) => packageName !== '@storybook/icons',
-);
 
 export default defineConfig(async (options) => {
   const commonConfig = {
@@ -26,10 +23,7 @@ export default defineConfig(async (options) => {
       format: ['esm', 'cjs'],
       target: [...BROWSER_TARGET, ...NODE_TARGET],
       platform: 'neutral',
-      external: [
-        ...globalManagerPackagesExcludingIcons,
-        ...globalPreviewPackages,
-      ],
+      external: [...globalManagerPackages, ...globalPreviewPackages],
     },
     {
       ...commonConfig,
@@ -37,7 +31,7 @@ export default defineConfig(async (options) => {
       format: ['esm'],
       target: BROWSER_TARGET,
       platform: 'browser',
-      external: globalManagerPackagesExcludingIcons,
+      external: globalManagerPackages,
     },
     {
       ...commonConfig,


### PR DESCRIPTION
From Storybook v8 onwards, the storybook icons package is included with the global manager packages, so we don't need to ship it as a dependency.

This is a breaking change because it's not compatible with Storybook v7, so the addon version is moving to v3.